### PR TITLE
[fix] copyPrivate이 processResources보다 먼저 실행 되도록 강제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
+tasks.named('processResources') {
+    dependsOn(copyPrivate)
+}
+
 task copyPrivate(type: Copy) {
     from './submodules/Prostargram_submodule-data'
     include "*.yml"


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #5 

## 📃 작업 사항
- copyPrivate이 processResources보다 먼저 실행 되도록 강제
